### PR TITLE
Enable shortcuts to package names

### DIFF
--- a/packages/cli/src/command-build.js
+++ b/packages/cli/src/command-build.js
@@ -420,7 +420,7 @@ function convertUserPackagesToPackages(directoriesOrPackageNames, packageInfos, 
         .map((d) => {
           if (directoryIsActuallyPackageName(d)) {
             const packageInfoEntry = Object.entries(packageInfos).find(
-              ([, packageInfo]) => d === packageInfo.name,
+              ([, packageInfo]) => d.length > 2? packageInfo.name.includes(d) : d === packageInfo.name,
             )
             if (!packageInfoEntry)
               throw new Error(

--- a/packages/cli/test/integ/build-flow.integ.test.js
+++ b/packages/cli/test/integ/build-flow.integ.test.js
@@ -240,6 +240,11 @@ describe('build-flow (integ)', function () {
     expect(await packageScriptCount(cwd, 'a', 'during2')).to.equal(2)
     expect(await packageScriptCount(cwd, 'b', 'during2')).to.equal(2)
     expect(await packageScriptCount(cwd, 'c', 'during2')).to.equal(1)
+
+    await runBuild(cwd, 'shortcut name build', undefined, ['a-pac'])
+    expect(await packageScriptCount(cwd, 'a', 'during2')).to.equal(1)
+    expect(await packageScriptCount(cwd, 'b', 'during2')).to.equal(1)
+    expect(await packageScriptCount(cwd, 'c', 'during2')).to.equal(1)
   })
 
   it('should use packages and uptos from biltrc', async () => {


### PR DESCRIPTION
In case of package name longer than 2 chars, enable shortcuts to package names 